### PR TITLE
Launch EMR in private subnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cdk.context.json
 build/
 node_modules/
 lerna-debug.log*

--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@ npx moonset config
 
 # run a job
 npx moonset deploy --job '{
-    "input": [
-      {"glue": { "db": "foo", "table": "apple"}}
-    ],
-    "task": [
-      {"hive": {"sqlFile": "s3://foo/hive.sql"}}
-    ],
-    "output": [
-      {"glue": { "db": "foo", "table": "orange"}}
-    ]
-}' 
+    "input": [{
+        "glue": { "db": "foo", "table": "apple", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
+    },{
+        "glue": { "db": "foo", "table": "orange", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
+    }],
+    "task": [{
+        "hive": {"sqlFile": "s3://foo/hive.sql"}
+    }],
+    "output": [{
+        "glue": { "db": "foo", "table": "pineapple", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
+    }]
+}'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ npx moonset deploy --job '{
 
 All resources is managed by AWS CDK so there is minimum effort for
 infrastructure setup. You can run it in a brand new account.
+
+The EMR is created in a VPC's private subnet, You can connect to both master
+and slave nodes via AWS Session Manager. No ssh key pair or bastion is needed.
+Follow [this guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html)
+to start a session to connect to EMR's instances.
+

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -27,7 +27,7 @@ npx lerna run --parallel watch
 # check the diff of this deployment and online cloudformation
 npx cdk diff --app ./build/cdk.out
 # update the dependencies in package.json
-npx npm-check-updates
+npx npm-check-updates -u
 ```
 
 The packages are publish in NPM. Here are some links:

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Moonset CLI",
   "keywords": [
     "Data Processing",
@@ -33,8 +33,8 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/executor": "^0.0.9",
-    "@moonset/util": "^0.0.9",
+    "@moonset/executor": "^0.0.10",
+    "@moonset/util": "^0.0.10",
     "@types/yargs": "^15.0.4",
     "typescript": "^3.8.3",
     "yargs": "^15.1.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Moonset CLI",
   "keywords": [
     "Data Processing",
@@ -33,8 +33,8 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/executor": "^0.0.10",
-    "@moonset/util": "^0.0.10",
+    "@moonset/executor": "^0.0.11",
+    "@moonset/util": "^0.0.11",
     "@types/yargs": "^15.0.4",
     "typescript": "^3.8.3",
     "yargs": "^15.1.0"

--- a/packages/executor/lib/constants.ts
+++ b/packages/executor/lib/constants.ts
@@ -11,5 +11,7 @@ export const MoonsetConstants = {
   EMR_EC2_PROFILE: 'MoonsetEmrEc2Profile',
   EMR_ROLE: 'MoonsetEmrRole',
   SCRIPT_RUNNER: 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
-  BUILD_TMP_DIR: './build/cdk.out',
+  BUILD_TMP_DIR: './build/',
+  CDK_OUT_DIR: 'cdk.out/',
+  MOONSET_PROPS: 'moonset.props'
 };

--- a/packages/executor/package-lock.json
+++ b/packages/executor/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moonset/executor",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/executor/package-lock.json
+++ b/packages/executor/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moonset/executor",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/executor",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The Moonset Executor",
   "keywords": [
     "AWS",
@@ -15,7 +15,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "script"
   ],
   "repository": {
     "type": "git",
@@ -40,8 +41,8 @@
     "@aws-cdk/aws-stepfunctions": "^1.27.0",
     "@aws-cdk/aws-stepfunctions-tasks": "^1.27.0",
     "@aws-cdk/core": "^1.27.0",
-    "@moonset/model": "^0.0.10",
-    "@moonset/util": "^0.0.10",
+    "@moonset/model": "^0.0.11",
+    "@moonset/util": "^0.0.11",
     "@types/node": "^13.9.0",
     "@types/uuid": "^7.0.0",
     "aws-cdk": "^1.27.0",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/executor",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "The Moonset Executor",
   "keywords": [
     "AWS",
@@ -40,8 +40,8 @@
     "@aws-cdk/aws-stepfunctions": "^1.27.0",
     "@aws-cdk/aws-stepfunctions-tasks": "^1.27.0",
     "@aws-cdk/core": "^1.27.0",
-    "@moonset/model": "^0.0.9",
-    "@moonset/util": "^0.0.9",
+    "@moonset/model": "^0.0.10",
+    "@moonset/util": "^0.0.10",
     "@types/node": "^13.9.0",
     "@types/uuid": "^7.0.0",
     "aws-cdk": "^1.27.0",

--- a/packages/model/package-lock.json
+++ b/packages/model/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/model/package-lock.json
+++ b/packages/model/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "The Moonset Model",
   "keywords": [
     "EMR",
@@ -31,7 +31,7 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/util": "^0.0.9",
+    "@moonset/util": "^0.0.10",
     "protobufjs": "^6.8.8"
   }
 }

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The Moonset Model",
   "keywords": [
     "EMR",
@@ -31,7 +31,7 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/util": "^0.0.10",
+    "@moonset/util": "^0.0.11",
     "protobufjs": "^6.8.8"
   }
 }

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -1,5 +1,5 @@
+import {Serde} from './serde';
 import * as inquirer from 'inquirer';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -45,7 +45,7 @@ const questions = [
 
 export class Config {
   static get(key: string) {
-    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const data = Serde.fromFile<{[k: string]: string}>(CONFIG_PATH);
     if (!data[key]) {
       throw Error(`${key} doesn't exist in ${CONFIG_PATH}.`);
     }
@@ -55,8 +55,7 @@ export class Config {
   static ask() {
     inquirer.prompt(questions).then((answers) => {
       console.log(`Write into ${CONFIG_PATH}`);
-      const content = JSON.stringify(answers, null, 4);
-      fs.writeFileSync(CONFIG_PATH, content, 'utf8');
+      Serde.toFile(answers, CONFIG_PATH);
     });
   }
 }

--- a/packages/util/lib/index.ts
+++ b/packages/util/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './config';
+export * from './serde';
 export * from './log';

--- a/packages/util/lib/serde.ts
+++ b/packages/util/lib/serde.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+
+export class Serde {
+  static toString<T>(obj: T): string {
+    return JSON.stringify(obj, null, 4);
+  }
+
+  static toFile<T>(obj: T, path: string) {
+    fs.writeFileSync(path, Serde.toString(obj), 'utf8');
+  }
+
+  static fromString<T>(json: string): T {
+    return JSON.parse(json);
+  }
+
+  static fromFile<T>(path: string): T {
+    return Serde.fromString(fs.readFileSync(path, 'utf8'));
+  }
+}

--- a/packages/util/package-lock.json
+++ b/packages/util/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/util/package-lock.json
+++ b/packages/util/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Moonset Utils",
   "keywords": [
     "Data Processing",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Moonset Utils",
   "keywords": [
     "Data Processing",


### PR DESCRIPTION
1. Create a VPC with public/private subnet and launch EMR in private subnet.
2. Connect to EMR master node and slave nodes with AWS Session Manager without key pair or bastion.
3.  Invoke the synthesis from CLI instead of merely app.synth(). Since the CLI will inject some runtime context for synthesis phase with some information like availability zones. Such information will be missing if directly call app.synth() without CLI.
