### PR TITLE
Support hive inline sql, local sql file and s3 sql file as input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,17 @@ npx moonset config
 npx moonset deploy --job '{
     "input": [{
         "glue": { "db": "foo", "table": "apple", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
-    },{
-        "glue": { "db": "foo", "table": "orange", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
     }],
     "task": [{
-        "hive": {"sqlFile": "s3://foo/hive.sql"}
+        "hive": {"sql": "insert overwrite table foo.pineapple partition (region_id=1, snapshot_date=\"2020-01-01\") select foo from foo.apple;"}
     }],
     "output": [{
         "glue": { "db": "foo", "table": "pineapple", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
     }]
 }'
-
 ```
 
-All resources is managed by AWS CDK so there is minimum effort for
+All resources are managed by AWS CDK so there is minimum effort for
 infrastructure setup. You can run it in a brand new account.
 
 The EMR is created in a VPC's private subnet, You can connect to both master

--- a/packages/cli/lib/moonset.ts
+++ b/packages/cli/lib/moonset.ts
@@ -5,7 +5,7 @@ import {Config, ConfigConstant as CC, logger} from '@moonset/util';
 export class Moonset {
   async run() {
     const argv = yargs
-        .command(['config'], 'configure the crendentials.')
+        .command(['config'], 'Configure the crendentials.')
         .command(['deploy'], 'Deploy the job.',
             (yargs) => yargs
                 .option('job', {type: 'string', desc: 'job payload',

--- a/packages/executor/lib/cdk/asset.ts
+++ b/packages/executor/lib/cdk/asset.ts
@@ -1,0 +1,79 @@
+import * as s3Asset from '@aws-cdk/aws-s3-assets';
+import * as cdk from '@aws-cdk/core';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as execa from 'execa';
+
+export interface HttpAssetProps {
+    // The source url.
+    readonly url: string
+}
+
+export class HttpAsset extends cdk.Construct {
+    readonly s3: s3Asset.Asset;
+
+    constructor(scope: cdk.Construct, id: string, props: HttpAssetProps) {
+      super(scope, id);
+
+      const tempdir= fs.mkdtempSync(path.join(os.tmpdir(), 'staging'));
+      const temppath = path.join(tempdir, 'tmpfile');
+
+      execa.sync('curl', ['-Lo', temppath, props.url]);
+
+      this.s3= new s3Asset.Asset(this, `${id}-HttpAsset`, {
+        path: temppath,
+      });
+    }
+
+    getS3Path(): string {
+      return `s3://${this.s3.s3BucketName}/${this.s3.s3ObjectKey}`;
+    }
+}
+
+export interface StringAssetProps {
+    // The source content.
+    readonly content: string
+}
+
+export class StringAsset extends cdk.Construct {
+    readonly s3: s3Asset.Asset;
+
+    constructor(scope: cdk.Construct, id: string, props: StringAssetProps) {
+      super(scope, id);
+
+      const tempdir= fs.mkdtempSync(path.join(os.tmpdir(), 'staging'));
+      const temppath = path.join(tempdir, 'tmpfile');
+
+      fs.writeFileSync(temppath, props.content);
+
+      this.s3= new s3Asset.Asset(this, `${id}-StringAsset`, {
+        path: temppath,
+      });
+    }
+
+    getS3Path(): string {
+      return `s3://${this.s3.s3BucketName}/${this.s3.s3ObjectKey}`;
+    }
+}
+
+export interface FileAssetProps {
+    // The local file path
+    readonly path: string
+}
+
+export class FileAsset extends cdk.Construct {
+    readonly s3: s3Asset.Asset;
+
+    constructor(scope: cdk.Construct, id: string, props: FileAssetProps) {
+      super(scope, id);
+
+      this.s3= new s3Asset.Asset(this, `${id}-FileAsset`, {
+        path: props.path,
+      });
+    }
+
+    getS3Path(): string {
+      return `s3://${this.s3.s3BucketName}/${this.s3.s3ObjectKey}`;
+    }
+}

--- a/packages/model/proto/task.proto
+++ b/packages/model/proto/task.proto
@@ -9,6 +9,7 @@ message Task {
 
 message Hive {
     string sql_file = 1;
+    string sql = 2;
 }
 
 message Spark {


### PR DESCRIPTION
Three modes are supported.

1. `sql : "select * from foo.table"`
2. `sqlFile: ./foo/hive.sql`
3. `sqlFile: s3://foo/hive.sql`