### PR TITLE
add logs to indicate the credential sources

### DIFF
--- a/packages/cli/lib/moonset.ts
+++ b/packages/cli/lib/moonset.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 import * as yargs from 'yargs';
 import {PluginHost, Executor} from '@moonset/executor';
-import {Config, ConfigConstant as CC, logger} from '@moonset/util';
+import {Config, ConfigConstant as CC, logger, CONFIG_PATH} from '@moonset/util';
 
 export class Moonset {
   async run() {
@@ -78,11 +78,13 @@ export class Moonset {
     }
     if (!process.env['AWS_ACCESS_KEY_ID'] &&
         Config.get(CC.WORKING_ACCESS_KEY)) {
+      logger.info(`Fetch AWS_ACCESS_KEY_ID from ${CONFIG_PATH}`);
       process.env['AWS_ACCESS_KEY_ID'] =
             Config.get(CC.WORKING_ACCESS_KEY);
     }
     if (!process.env['AWS_SECRET_ACCESS_KEY']&&
         Config.get(CC.WORKING_SECRET_KEY)) {
+      logger.info(`Fetch AWS_SECRET_ACCESS_KEY from ${CONFIG_PATH}`);
       process.env['AWS_SECRET_ACCESS_KEY'] =
             Config.get(CC.WORKING_SECRET_KEY);
     }

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const CONFIG_FILE = '.moonsetrc';
-const CONFIG_PATH = path.join(os.homedir(), CONFIG_FILE);
+export const CONFIG_PATH = path.join(os.homedir(), CONFIG_FILE);
 
 export const ConfigConstant = {
   WORKING_ACCOUNT: 'WORKING_ACCOUNT',


### PR DESCRIPTION
Here is the new log. You can see the two lines which begin with "info: Fetch AWS..".

```
➜  cli git:(creds-log) ✗ npm run cli -- run  \
    --plugin $(readlink -f ../plugins/platform-emr/)  \
    --plugin $(readlink -f ../plugins/data-glue/)  \
    --job  '{}'

> moonset@0.0.20 cli /home/zhihaow/workspace/mine/Moonset/packages/cli
> ./cli.js "run" "--plugin" "/home/zhihaow/workspace/mine/Moonset/packages/plugins/platform-emr" "--plugin" "/home/zhihaow/workspace/mine/Moonset/packages/plugins/data-glue" "--job" "{}"

info: The plugins: /home/zhihaow/workspace/mine/Moonset/packages/plugins/platform-emr,/home/zhihaow/workspace/mine/Moonset/packages/plugins/data-glue. The hooks: platform.emr.init,platform.emr.task,data.glue.init,data.glue.import,data.glue.export. {"service":"user-service"}
info: Fetch AWS_ACCESS_KEY_ID from /home/zhihaow/.moonsetrc {"service":"user-service"}
info: Fetch AWS_SECRET_ACCESS_KEY from /home/zhihaow/.moonsetrc {"service":"user-service"}
Successfully synthesized to /home/zhihaow/workspace/mine/Moonset/packages/cli/build/cdk.out
Supply a stack id (MoonsetEmrStack, MoonsetInfraStack, MoonsetStepFunctionStack) to display its template.
MoonsetEmrStack
MoonsetEmrStack: deploying...
MoonsetEmrStack: creating CloudFormation changeset...
```